### PR TITLE
feat: Enhanced remote CLI with run/git commands and TTY handling

### DIFF
--- a/bin/netcup-kube-remote
+++ b/bin/netcup-kube-remote
@@ -18,7 +18,7 @@ set -euo pipefail
 #   bin/netcup-kube-remote host --user ops run bootstrap
 #   bin/netcup-kube-remote host --user ops run pair
 #   bin/netcup-kube-remote host --user ops run dns
-#   bin/netcup-kube-remote host --user ops run dns --type edge-http --domains "kube.example.com|demo.example.com"
+#   bin/netcup-kube-remote host --user ops run dns --type edge-http --domains "kube.example.com,demo.example.com"
 #
 # After bootstrap you can SSH as the new user: ssh <user>@<host>
 
@@ -70,7 +70,7 @@ Examples:
   netcup-kube-remote run bootstrap
   netcup-kube-remote run pair
   netcup-kube-remote run dns
-  netcup-kube-remote run dns --type edge-http --domains "kube.example.com|demo.example.com"
+  netcup-kube-remote run dns --type edge-http --domains "kube.example.com,demo.example.com"
   netcup-kube-remote run --env-file ./config/netcup-kube.env bootstrap
 
 Notes:


### PR DESCRIPTION
## Description

Major improvements to `netcup-kube-remote` for better remote command execution and repository management.

## New Features

### 1. `run` Command - Execute netcup-kube Commands Remotely
- Forced TTY mode by default (makes `/dev/tty` prompts work)
- Inject environment variables with `--env-file`
- Auto-checkout branches with `--branch` / `--ref`
- Uses `bash -lc` for proper login shell environment
- Restricted to netcup-kube subcommands only (security)

### 2. `git` Command - Remote Repository Management
- Checkout specific branches or refs
- Pull latest changes
- Safer than raw SSH git commands

### 3. Improved UX
- Better help documentation with examples
- Proper argument quoting for complex parameters
- `--no-tty` option when TTY not needed
- Prevents running as root (enforces `--user`)
- Clear error messages

## Usage Examples

```bash
# Run bootstrap remotely
netcup-kube-remote run bootstrap

# Run with environment file and branch checkout
netcup-kube-remote run --env-file prod.env --branch release provision

# Update remote repo
netcup-kube-remote git --branch main --pull

# Complex command with passthrough args
netcup-kube-remote run -- dns --type edge-http --domains "app.example.com"
```

## Technical Details

- **TTY Handling**: Uses `ssh -t` to force pseudo-terminal allocation
- **Shell Environment**: Wraps commands in `bash -lc` to ensure `.profile` is loaded
- **Argument Safety**: Proper shell quoting for all remote parameters
- **Error Prevention**: Validates commands before execution

## Benefits

- Enables reliable remote provisioning and management
- Fixes issues with prompts not working over SSH
- Foundation for automated deployments
- Safer than manual SSH commands

## Testing

- [x] `netcup-kube-remote help` shows documentation
- [x] `run` command works with TTY
- [x] `git` operations work correctly
- [x] Environment file injection works
- [x] Branch switching works

## Dependencies

- Depends on: PR #5 (Local Development Tooling) ✅ merged

## Part of

Extracted from spike branch `feat/remote-run-wrapper` (PR 2/8)