### PR TITLE
[recipes] Fix llm-proxy platform Postgres sslmode default

### DIFF
--- a/scripts/recipes/llm-proxy/README.md
+++ b/scripts/recipes/llm-proxy/README.md
@@ -61,6 +61,11 @@ LLM_PROXY_DATABASE_URL="postgres://user:pass@host:5432/db?sslmode=require" \
 netcup-kube install llm-proxy --create-secret
 ```
 
+Platform Postgres auto-detection (Bitnami `svc/postgres-postgresql`):
+
+- By default, this recipe builds a `DATABASE_URL` using `sslmode=disable`.
+- If your in-cluster Postgres is configured for TLS, override with `LLM_PROXY_POSTGRES_SSLMODE=require`.
+
 Enable Prometheus metrics with kube-prometheus-stack:
 
 ```bash


### PR DESCRIPTION
## Summary

- Fixes `netcup-kube install llm-proxy` when platform Bitnami Postgres is present by defaulting the auto-generated `DATABASE_URL` to `sslmode=disable` (the in-cluster Postgres commonly has TLS disabled, and `sslmode=require` causes llm-proxy to crash-loop).
- Ensures pods roll on Secret updates (`--create-secret`) so updated env-from-secret values take effect.
- Updates recipe docs to explain the default and how to override when Postgres TLS is enabled.

## Checklist

- [x] `make check` passes (shfmt + shellcheck)
- [x] Docs updated (recipe README)
- [x] Tested on a Debian 13 server

## Notes for reviewers

Observed failure mode: llm-proxy pods crash-loop with `server refused TLS connection` when `DATABASE_URL` includes `sslmode=require` against the platform Postgres service.
