### PR TITLE
Cloud agents starter skill

### DIFF
--- a/.cursor/skills/cloud_agents_starter.md
+++ b/.cursor/skills/cloud_agents_starter.md
@@ -43,7 +43,7 @@ Workflow:
 1. `make build`
 2. `go test ./cmd/... ./internal/...`
 3. `./bin/netcup-kube remote --help`
-4. `./bin/netcup-kube ssh tunnel status`
+4. `./bin/netcup-kube ssh --help`
 
 Success signal: build succeeds, tests pass, and command help/status return without panic.
 
@@ -75,9 +75,9 @@ Workflow:
 3. Remote smoke (non-destructive):
    - `./bin/netcup-kube remote --host <host-or-ip> --user <user> smoke`
 4. Tunnel-based kubectl access:
-   - `./bin/netcup-kube ssh tunnel start`
+   - `./bin/netcup-kube ssh tunnel start --host <host-or-ip> --user <user>`
    - `kubectl cluster-info`
-   - `./bin/netcup-kube ssh tunnel stop`
+   - `./bin/netcup-kube ssh tunnel stop --host <host-or-ip> --user <user>`
 
 Success signal: SSH works, remote smoke completes, tunnel enables `kubectl cluster-info`.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds a new starter skill for Cloud agents (`.cursor/skills/cloud_agents_starter.md`) providing practical day-0 setup, run, and test workflows. It covers login, app startup, feature flags, and area-specific testing (Go CLI, shell, remote ops, recipes), including a section on skill maintenance.

## Checklist

- [x] `make check` passes (shfmt + shellcheck)
- [x] Docs updated (README/AGENTS.md/COPILOT.md if needed)
- [ ] Tested on a Debian 13 server

## Notes for reviewers

This change is documentation-only, adding a new skill file. No runtime or UI changes were introduced, so specific server testing was not performed.

---
<p><a href="https://cursor.com/agents/bc-cff9ae03-14e8-492c-9943-501b3a81b507"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cff9ae03-14e8-492c-9943-501b3a81b507"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->