### PR TITLE
SPIKE: Restore experimental recipes for truthbrush and VS Code proxy

### DIFF
--- a/cmd/netcup-kube/install.go
+++ b/cmd/netcup-kube/install.go
@@ -32,11 +32,13 @@ Available recipes:
   argo-cd                  Install Argo CD (GitOps continuous delivery tool)
   postgres                 Install PostgreSQL (Bitnami Helm chart)
   redis                    Install Redis (Bitnami Helm chart)
+	truthbrush-poller        Install low-latency Truth poller with OpenClaw webhook delivery
   sealed-secrets           Install Sealed Secrets (encrypt secrets for Git)
   redisinsight             Install RedisInsight (Redis GUI)
   kube-prometheus-stack    Install Grafana + Prometheus + Alertmanager
   dashboard                Install Kubernetes Dashboard (official web UI)
   llm-proxy                Install llm-proxy (Helm chart; Secret-backed config)
+	vscode-copilot-proxy     Install internal-only OpenVSCode Server for Copilot Proxy
   openclaw                 Install OpenClaw with kernel-level network monitoring
   zeroclaw                 Install ZeroClaw AI agent (TOML config, Anthropic provider)
 

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -75,7 +75,9 @@ netcup-kube install <recipe> [recipe-options]
 - `argo-cd` — Install Argo CD (GitOps continuous delivery tool)
 - `postgres` — Install PostgreSQL (Bitnami Helm chart)
 - `redis` — Install Redis (Bitnami Helm chart)
+- `truthbrush-poller` — Install low-latency Truth poller that posts to OpenClaw webhook
 - `llm-proxy` — Install llm-proxy (Helm chart; Secret-backed config)
+- `vscode-copilot-proxy` — Install internal-only OpenVSCode Server for Copilot Proxy plugin runtime
 - `sealed-secrets` — Install Sealed Secrets (encrypt secrets for Git)
 - `redisinsight` — Install RedisInsight (Redis GUI)
 - `kube-prometheus-stack` — Install Grafana + Prometheus + Alertmanager

--- a/scripts/recipes/README.md
+++ b/scripts/recipes/README.md
@@ -45,7 +45,9 @@ NAMESPACE=prod-db STORAGE=50Gi netcup-kube install postgres
 - **dashboard**: Kubernetes Dashboard
 - **redisinsight**: Redis GUI for development
 - **llm-proxy**: Install llm-proxy from its Helm chart (Secret-backed config)
+- **vscode-copilot-proxy**: Internal-only OpenVSCode Server for Copilot Proxy plugin runtime
 - **openclaw**: OpenClaw agent with mandatory kernel-level network monitoring
+- **truthbrush-poller**: Low-latency Truth poller service that forwards new posts to an OpenClaw webhook
 - **zeroclaw**: ZeroClaw AI agent (bundled Helm chart, TOML config, Anthropic provider, dedicated namespace)
 
 ## Usage

--- a/scripts/recipes/truthbrush-poller/README.md
+++ b/scripts/recipes/truthbrush-poller/README.md
@@ -1,0 +1,175 @@
+# truthbrush-poller recipe
+
+Deploys a low-latency Truth poller as a Kubernetes `Deployment`.
+
+The poller:
+- uses [truthbrush](https://github.com/stanfordio/truthbrush) against Truth Social,
+- stores minimal state in SQLite (`/data/state.db` on a PVC),
+- posts only new posts to your OpenClaw webhook URL.
+
+## Install
+
+```bash
+TRUTHSOCIAL_TOKEN="<truthsocial-token>" \
+netcup-kube install truthbrush-poller \
+  --namespace openclaw \
+  --webhook-url "https://<openclaw-host>/hooks/truthbrush"
+```
+
+With username/password login and webhook auth:
+
+```bash
+TRUTHSOCIAL_USERNAME="<truthsocial-username>" \
+TRUTHSOCIAL_PASSWORD="<truthsocial-password>" \
+OPENCLAW_WEBHOOK_BEARER="<token>" \
+OPENCLAW_WEBHOOK_SIGNING_KEY="<hmac-key>" \
+netcup-kube install truthbrush-poller \
+  --webhook-url "https://<openclaw-host>/hooks/truthbrush"
+```
+
+Use an existing secret instead of creating one:
+
+```bash
+netcup-kube install truthbrush-poller \
+  --secret-name truthbrush-runtime-secrets \
+  --use-existing-secret
+```
+
+Expected secret keys:
+- `truthsocial-token` (or both `truthsocial-username` + `truthsocial-password`)
+- `webhook-url`
+- `webhook-bearer` (optional)
+- `webhook-signing-key` (optional)
+
+## Common options
+
+- `--poll-seconds` (default `20`)
+- `--target-handle` (default `realDonaldTrump`)
+- `--secret-name` (default `<name>-secrets`)
+- `--use-existing-secret` (default `false`)
+- `--state-size` (default `1Gi`)
+- `--name` (default `truthbrush-poller`)
+
+## Payload contract
+
+The webhook receives JSON:
+
+```json
+{
+  "source": "truthbrush-poller",
+  "event": "truthsocial.new_post",
+  "generatedAt": "2026-03-03T21:34:56Z",
+  "idempotencyKey": "truthsocial:114291234567890123",
+  "post": {
+    "id": "114291234567890123",
+    "url": "https://truthsocial.com/@realDonaldTrump/posts/114291234567890123",
+    "createdAt": "2026-03-03T20:34:00.000Z",
+    "content": "..."
+  }
+}
+```
+
+Headers:
+- `X-Idempotency-Key: truthsocial:<post-id>`
+- `X-Truthbrush-Event: truthsocial.new_post`
+- `Authorization: Bearer <token>` (if configured)
+- `X-Truthbrush-Signature: sha256=<hex>` (if signing key configured)
+
+## Uninstall
+
+```bash
+netcup-kube install truthbrush-poller --uninstall
+```
+
+Delete secret as well:
+
+```bash
+netcup-kube install truthbrush-poller --uninstall --delete-secret
+```# truthbrush-poller recipe
+
+Deploys a low-latency Truth poller as a Kubernetes `Deployment`.
+
+The poller:
+- uses [truthbrush](https://github.com/stanfordio/truthbrush) against Truth Social,
+- stores minimal state in SQLite (`/data/state.db` on a PVC),
+- posts only new posts to your OpenClaw webhook URL.
+
+## Install
+
+```bash
+TRUTHSOCIAL_TOKEN="<truthsocial-token>" \
+netcup-kube install truthbrush-poller \
+  --namespace openclaw \
+  --webhook-url "https://<openclaw-host>/hooks/truthbrush"
+```
+
+With username/password login and webhook auth:
+
+```bash
+TRUTHSOCIAL_USERNAME="<truthsocial-username>" \
+TRUTHSOCIAL_PASSWORD="<truthsocial-password>" \
+OPENCLAW_WEBHOOK_BEARER="<token>" \
+OPENCLAW_WEBHOOK_SIGNING_KEY="<hmac-key>" \
+netcup-kube install truthbrush-poller \
+  --webhook-url "https://<openclaw-host>/hooks/truthbrush"
+```
+
+Use an existing secret instead of creating one:
+
+```bash
+netcup-kube install truthbrush-poller \
+  --secret-name truthbrush-runtime-secrets \
+  --use-existing-secret
+```
+
+Expected secret keys:
+- `truthsocial-token` (or both `truthsocial-username` + `truthsocial-password`)
+- `webhook-url`
+- `webhook-bearer` (optional)
+- `webhook-signing-key` (optional)
+
+## Common options
+
+- `--poll-seconds` (default `20`)
+- `--target-handle` (default `realDonaldTrump`)
+- `--secret-name` (default `<name>-secrets`)
+- `--use-existing-secret` (default `false`)
+- `--state-size` (default `1Gi`)
+- `--name` (default `truthbrush-poller`)
+
+## Payload contract
+
+The webhook receives JSON:
+
+```json
+{
+  "source": "truthbrush-poller",
+  "event": "truthsocial.new_post",
+  "generatedAt": "2026-03-03T21:34:56Z",
+  "idempotencyKey": "truthsocial:114291234567890123",
+  "post": {
+    "id": "114291234567890123",
+    "url": "https://truthsocial.com/@realDonaldTrump/posts/114291234567890123",
+    "createdAt": "2026-03-03T20:34:00.000Z",
+    "content": "..."
+  }
+}
+```
+
+Headers:
+- `X-Idempotency-Key: truthsocial:<post-id>`
+- `X-Truthbrush-Event: truthsocial.new_post`
+- `Authorization: Bearer <token>` (if configured)
+- `X-Truthbrush-Signature: sha256=<hex>` (if signing key configured)
+
+## Uninstall
+
+```bash
+netcup-kube install truthbrush-poller --uninstall
+```
+
+Delete secret as well:
+
+```bash
+netcup-kube install truthbrush-poller --uninstall --delete-secret
+```

--- a/scripts/recipes/truthbrush-poller/install.sh
+++ b/scripts/recipes/truthbrush-poller/install.sh
@@ -1,0 +1,1171 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# shellcheck disable=SC1091
+source "${SCRIPTS_DIR}/lib/common.sh"
+# shellcheck disable=SC1091
+source "${SCRIPTS_DIR}/recipes/lib.sh"
+
+usage() {
+  cat << 'EOF'
+Deploy a low-latency Truth poller as a Kubernetes Deployment.
+
+The poller uses Truthbrush (Truth Social API client), stores minimal state in
+SQLite, and forwards only new posts to an OpenClaw webhook.
+
+Usage:
+  netcup-kube install truthbrush-poller [options]
+
+Options:
+  --namespace <name>            Namespace to install into (default: openclaw).
+  --name <name>                 Base name for Deployment/ConfigMap/Secret/PVC (default: truthbrush-poller).
+  --secret-name <name>          Secret name for credentials/webhook config (default: <name>-secrets).
+  --image <image>               Container image (default: python:3.12-slim).
+  --target-handle <handle>      Truth Social account to poll (default: realDonaldTrump).
+  --poll-seconds <seconds>      Poll interval in seconds (default: 20).
+  --use-existing-secret         Use an existing Kubernetes Secret instead of creating/updating one.
+  --webhook-url <url>           OpenClaw webhook endpoint URL (required unless --uninstall).
+  --webhook-bearer <token>      Optional bearer token sent as Authorization header.
+  --webhook-signing-key <key>   Optional HMAC signing key for X-Truthbrush-Signature.
+  --truthsocial-token <token>   Truth Social auth token for Truthbrush.
+  --truthsocial-username <name> Truth Social username for Truthbrush login.
+  --truthsocial-password <pass> Truth Social password for Truthbrush login.
+  --state-size <size>           PVC size for SQLite state (default: 1Gi).
+  --delete-secret               Also delete Secret during --uninstall.
+  --uninstall                   Uninstall poller resources.
+  -h, --help                    Show this help.
+
+Environment:
+  KUBECONFIG                    Kubeconfig to use. If not set, defaults to /etc/rancher/k3s/k3s.yaml (on the node).
+  TRUTHBRUSH_NAMESPACE          Alternative to --namespace.
+  TRUTHBRUSH_NAME               Alternative to --name.
+  TRUTHBRUSH_SECRET_NAME        Alternative to --secret-name.
+  TRUTHBRUSH_IMAGE              Alternative to --image.
+  TRUTHBRUSH_TARGET_HANDLE      Alternative to --target-handle.
+  TRUTHBRUSH_POLL_SECONDS       Alternative to --poll-seconds.
+  TRUTHBRUSH_USE_EXISTING_SECRET true|false (default: false).
+  OPENCLAW_WEBHOOK_URL          Alternative to --webhook-url.
+  OPENCLAW_WEBHOOK_BEARER       Alternative to --webhook-bearer.
+  OPENCLAW_WEBHOOK_SIGNING_KEY  Alternative to --webhook-signing-key.
+  TRUTHSOCIAL_TOKEN             Alternative to --truthsocial-token.
+  TRUTHSOCIAL_USERNAME          Alternative to --truthsocial-username.
+  TRUTHSOCIAL_PASSWORD          Alternative to --truthsocial-password.
+  TRUTHBRUSH_STATE_SIZE         Alternative to --state-size.
+  TRUTHBRUSH_DELETE_SECRET      true|false (default: false).
+  CONFIRM=true                  Required for non-interactive --uninstall.
+
+Notes:
+  - This recipe is idempotent (kubectl apply based).
+  - Secrets are stored in a Kubernetes Secret and never printed.
+  - Truthbrush source auth must be provided via Secret keys (token or username/password).
+  - The payload includes an idempotency key and post metadata.
+EOF
+}
+
+NAMESPACE="${TRUTHBRUSH_NAMESPACE:-${NAMESPACE_OPENCLAW}}"
+NAME="${TRUTHBRUSH_NAME:-truthbrush-poller}"
+SECRET_NAME="${TRUTHBRUSH_SECRET_NAME:-}"
+IMAGE="${TRUTHBRUSH_IMAGE:-python:3.12-slim}"
+TARGET_HANDLE="${TRUTHBRUSH_TARGET_HANDLE:-realDonaldTrump}"
+POLL_SECONDS="${TRUTHBRUSH_POLL_SECONDS:-20}"
+USE_EXISTING_SECRET="${TRUTHBRUSH_USE_EXISTING_SECRET:-false}"
+WEBHOOK_URL="${OPENCLAW_WEBHOOK_URL:-}"
+WEBHOOK_BEARER="${OPENCLAW_WEBHOOK_BEARER:-}"
+WEBHOOK_SIGNING_KEY="${OPENCLAW_WEBHOOK_SIGNING_KEY:-}"
+TRUTHSOCIAL_TOKEN="${TRUTHSOCIAL_TOKEN:-}"
+TRUTHSOCIAL_USERNAME="${TRUTHSOCIAL_USERNAME:-}"
+TRUTHSOCIAL_PASSWORD="${TRUTHSOCIAL_PASSWORD:-}"
+STATE_SIZE="${TRUTHBRUSH_STATE_SIZE:-1Gi}"
+DELETE_SECRET="${TRUTHBRUSH_DELETE_SECRET:-false}"
+UNINSTALL="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --namespace)
+      shift
+      NAMESPACE="${1:-}"
+      ;;
+    --namespace=*)
+      NAMESPACE="${1#*=}"
+      ;;
+    --name)
+      shift
+      NAME="${1:-}"
+      ;;
+    --name=*)
+      NAME="${1#*=}"
+      ;;
+    --secret-name)
+      shift
+      SECRET_NAME="${1:-}"
+      ;;
+    --secret-name=*)
+      SECRET_NAME="${1#*=}"
+      ;;
+    --image)
+      shift
+      IMAGE="${1:-}"
+      ;;
+    --image=*)
+      IMAGE="${1#*=}"
+      ;;
+    --target-handle)
+      shift
+      TARGET_HANDLE="${1:-}"
+      ;;
+    --target-handle=*)
+      TARGET_HANDLE="${1#*=}"
+      ;;
+    --poll-seconds)
+      shift
+      POLL_SECONDS="${1:-}"
+      ;;
+    --poll-seconds=*)
+      POLL_SECONDS="${1#*=}"
+      ;;
+    --use-existing-secret)
+      USE_EXISTING_SECRET="true"
+      ;;
+    --webhook-url)
+      shift
+      WEBHOOK_URL="${1:-}"
+      ;;
+    --webhook-url=*)
+      WEBHOOK_URL="${1#*=}"
+      ;;
+    --webhook-bearer)
+      shift
+      WEBHOOK_BEARER="${1:-}"
+      ;;
+    --webhook-bearer=*)
+      WEBHOOK_BEARER="${1#*=}"
+      ;;
+    --webhook-signing-key)
+      shift
+      WEBHOOK_SIGNING_KEY="${1:-}"
+      ;;
+    --webhook-signing-key=*)
+      WEBHOOK_SIGNING_KEY="${1#*=}"
+      ;;
+    --truthsocial-token)
+      shift
+      TRUTHSOCIAL_TOKEN="${1:-}"
+      ;;
+    --truthsocial-token=*)
+      TRUTHSOCIAL_TOKEN="${1#*=}"
+      ;;
+    --truthsocial-username)
+      shift
+      TRUTHSOCIAL_USERNAME="${1:-}"
+      ;;
+    --truthsocial-username=*)
+      TRUTHSOCIAL_USERNAME="${1#*=}"
+      ;;
+    --truthsocial-password)
+      shift
+      TRUTHSOCIAL_PASSWORD="${1:-}"
+      ;;
+    --truthsocial-password=*)
+      TRUTHSOCIAL_PASSWORD="${1#*=}"
+      ;;
+    --state-size)
+      shift
+      STATE_SIZE="${1:-}"
+      ;;
+    --state-size=*)
+      STATE_SIZE="${1#*=}"
+      ;;
+    --delete-secret)
+      DELETE_SECRET="true"
+      ;;
+    --uninstall)
+      UNINSTALL="true"
+      ;;
+    -h | --help | help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+  shift || true
+done
+
+[[ -n "${NAMESPACE}" ]] || die "Namespace is required"
+[[ -n "${NAME}" ]] || die "Name is required"
+if [[ -z "${SECRET_NAME}" ]]; then
+  SECRET_NAME="${NAME}-secrets"
+fi
+[[ -n "${IMAGE}" ]] || die "Image is required"
+[[ -n "${TARGET_HANDLE}" ]] || die "Target handle is required"
+[[ -n "${POLL_SECONDS}" ]] || die "Poll seconds is required"
+[[ "${POLL_SECONDS}" =~ ^[0-9]+$ ]] || die "Poll seconds must be an integer"
+((POLL_SECONDS > 0)) || die "Poll seconds must be > 0"
+USE_EXISTING_SECRET="$(bool_norm "${USE_EXISTING_SECRET}")"
+DELETE_SECRET="$(bool_norm "${DELETE_SECRET}")"
+
+CONFIGMAP_NAME="${NAME}-script"
+PVC_NAME="${NAME}-state"
+
+if [[ "${UNINSTALL}" == "true" ]]; then
+  recipe_confirm_or_die "Uninstall truthbrush-poller (${NAME}) from namespace ${NAMESPACE}"
+  log "Uninstalling truthbrush-poller resources from namespace: ${NAMESPACE}"
+  recipe_kdelete deployment "${NAME}" -n "${NAMESPACE}"
+  recipe_kdelete configmap "${CONFIGMAP_NAME}" -n "${NAMESPACE}"
+  if [[ "${DELETE_SECRET}" == "true" ]]; then
+    recipe_kdelete secret "${SECRET_NAME}" -n "${NAMESPACE}"
+  fi
+  recipe_kdelete pvc "${PVC_NAME}" -n "${NAMESPACE}"
+  log "Uninstall requested. Note: data may persist if the storage class retains volumes."
+  exit 0
+fi
+
+log "Installing truthbrush-poller into namespace: ${NAMESPACE}"
+recipe_ensure_namespace "${NAMESPACE}"
+
+if [[ "${USE_EXISTING_SECRET}" == "true" ]]; then
+  log "Using existing Kubernetes Secret (${SECRET_NAME})"
+  k get secret "${SECRET_NAME}" -n "${NAMESPACE}" > /dev/null
+else
+  [[ -n "${WEBHOOK_URL}" ]] || die "--webhook-url (or OPENCLAW_WEBHOOK_URL) is required when creating secret"
+  if [[ -z "${TRUTHSOCIAL_TOKEN}" ]]; then
+    [[ -n "${TRUTHSOCIAL_USERNAME}" ]] || die "Provide TRUTHSOCIAL_TOKEN or TRUTHSOCIAL_USERNAME+TRUTHSOCIAL_PASSWORD"
+    [[ -n "${TRUTHSOCIAL_PASSWORD}" ]] || die "Provide TRUTHSOCIAL_TOKEN or TRUTHSOCIAL_USERNAME+TRUTHSOCIAL_PASSWORD"
+  fi
+
+  log "Applying Kubernetes Secret (${SECRET_NAME})"
+  k create secret generic "${SECRET_NAME}" \
+    -n "${NAMESPACE}" \
+    --from-literal=webhook-url="${WEBHOOK_URL}" \
+    --from-literal=webhook-bearer="${WEBHOOK_BEARER}" \
+    --from-literal=webhook-signing-key="${WEBHOOK_SIGNING_KEY}" \
+    --from-literal=truthsocial-token="${TRUTHSOCIAL_TOKEN}" \
+    --from-literal=truthsocial-username="${TRUTHSOCIAL_USERNAME}" \
+    --from-literal=truthsocial-password="${TRUTHSOCIAL_PASSWORD}" \
+    --dry-run=client -o yaml | k apply -f -
+fi
+
+log "Applying ConfigMap (${CONFIGMAP_NAME})"
+cat << EOF | k apply -n "${NAMESPACE}" -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ${CONFIGMAP_NAME}
+data:
+  poller.py: |
+    #!/usr/bin/env python3
+    import datetime
+    import hashlib
+    import hmac
+    import json
+    import os
+    import sqlite3
+    import time
+    from html import unescape
+    import urllib.error
+    import urllib.request
+
+    from truthbrush import Api
+
+    TARGET_HANDLE = os.environ.get("TARGET_HANDLE", "realDonaldTrump").strip()
+    WEBHOOK_URL = os.environ.get("WEBHOOK_URL", "").strip()
+    WEBHOOK_BEARER = os.environ.get("WEBHOOK_BEARER", "").strip()
+    WEBHOOK_SIGNING_KEY = os.environ.get("WEBHOOK_SIGNING_KEY", "").strip()
+    TRUTHSOCIAL_TOKEN = os.environ.get("TRUTHSOCIAL_TOKEN", "").strip() or None
+    TRUTHSOCIAL_USERNAME = os.environ.get("TRUTHSOCIAL_USERNAME", "").strip() or None
+    TRUTHSOCIAL_PASSWORD = os.environ.get("TRUTHSOCIAL_PASSWORD", "").strip() or None
+    POLL_SECONDS = int(os.environ.get("POLL_SECONDS", "20"))
+    DB_PATH = os.environ.get("DB_PATH", "/data/state.db")
+    TIMEOUT_SECONDS = int(os.environ.get("HTTP_TIMEOUT_SECONDS", "15"))
+
+
+    def log(msg):
+      now = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+      print(f"[{now}] {msg}", flush=True)
+
+
+    def clean_content(html_text):
+      text = unescape(str(html_text or ""))
+      text = text.replace("<br>", " ").replace("<br/>", " ").replace("<br />", " ")
+      while "<" in text and ">" in text:
+        start = text.find("<")
+        end = text.find(">", start)
+        if end == -1:
+          break
+        text = text[:start] + " " + text[end + 1 :]
+      return " ".join(text.split())
+
+
+    def db_connect():
+      os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
+      conn = sqlite3.connect(DB_PATH)
+      conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS state (
+          key TEXT PRIMARY KEY,
+          value TEXT NOT NULL
+        )
+        """
+      )
+      conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS deliveries (
+          idempotency_key TEXT PRIMARY KEY,
+          post_id TEXT NOT NULL,
+          delivered_at TEXT NOT NULL,
+          status TEXT NOT NULL
+        )
+        """
+      )
+      conn.commit()
+      return conn
+
+
+    def get_state(conn, key):
+      row = conn.execute("SELECT value FROM state WHERE key = ?", (key,)).fetchone()
+      return row[0] if row else None
+
+
+    def set_state(conn, key, value):
+      conn.execute(
+        "INSERT OR REPLACE INTO state (key, value) VALUES (?, ?)",
+        (key, value),
+      )
+      conn.commit()
+
+
+    def mark_delivery(conn, idempotency_key, post_id, status):
+      ts = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+      conn.execute(
+        "INSERT OR REPLACE INTO deliveries (idempotency_key, post_id, delivered_at, status) VALUES (?, ?, ?, ?)",
+        (idempotency_key, post_id, ts, status),
+      )
+      conn.commit()
+
+
+    def signature_for(body):
+      if not WEBHOOK_SIGNING_KEY:
+        return ""
+      digest = hmac.new(
+        WEBHOOK_SIGNING_KEY.encode("utf-8"),
+        body,
+        hashlib.sha256,
+      ).hexdigest()
+      return f"sha256={digest}"
+
+
+    def post_webhook(post):
+      idempotency_key = f"truthsocial:{post['id']}"
+      payload = {
+        "source": "truthbrush-poller",
+        "event": "truthsocial.new_post",
+        "generatedAt": datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "idempotencyKey": idempotency_key,
+        "post": post,
+      }
+      body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+
+      headers = {
+        "Content-Type": "application/json",
+        "X-Idempotency-Key": idempotency_key,
+        "X-Truthbrush-Event": "truthsocial.new_post",
+      }
+      if WEBHOOK_BEARER:
+        headers["Authorization"] = f"Bearer {WEBHOOK_BEARER}"
+
+      sig = signature_for(body)
+      if sig:
+        headers["X-Truthbrush-Signature"] = sig
+
+      req = urllib.request.Request(WEBHOOK_URL, data=body, headers=headers, method="POST")
+      with urllib.request.urlopen(req, timeout=TIMEOUT_SECONDS) as res:
+        status = getattr(res, "status", 200)
+        if status < 200 or status >= 300:
+          raise RuntimeError(f"webhook returned status {status}")
+      return idempotency_key
+
+
+    def normalize_post(raw_post):
+      post_id = str(raw_post.get("id", "")).strip()
+      if not post_id:
+        return None
+      return {
+        "id": post_id,
+        "url": raw_post.get("url") or "",
+        "createdAt": raw_post.get("created_at") or "",
+        "content": clean_content(raw_post.get("content") or ""),
+      }
+
+
+    def fetch_new_posts(api, since_id):
+      posts = list(api.pull_statuses(username=TARGET_HANDLE, replies=False, since_id=since_id, verbose=False))
+      normalized = []
+      for post in posts:
+        candidate = normalize_post(post)
+        if candidate is not None:
+          normalized.append(candidate)
+      normalized.sort(key=lambda p: int(p["id"]))
+      return normalized
+
+
+    def bootstrap_cursor(conn, posts):
+      last_seen_id = get_state(conn, "last_seen_id")
+      if last_seen_id is not None:
+        return
+      if not posts:
+        return
+      latest = max(posts, key=lambda p: int(p["id"]))
+      set_state(conn, "last_seen_id", latest["id"])
+      log(f"bootstrapped cursor at {latest['id']}; waiting for fresh posts")
+
+
+    def main_loop():
+      if not WEBHOOK_URL:
+        raise RuntimeError("WEBHOOK_URL is required")
+      if TRUTHSOCIAL_TOKEN is None and (TRUTHSOCIAL_USERNAME is None or TRUTHSOCIAL_PASSWORD is None):
+        raise RuntimeError("Truth Social credentials missing (set TRUTHSOCIAL_TOKEN or TRUTHSOCIAL_USERNAME+TRUTHSOCIAL_PASSWORD)")
+
+      conn = db_connect()
+      api = Api(
+        username=TRUTHSOCIAL_USERNAME,
+        password=TRUTHSOCIAL_PASSWORD,
+        token=TRUTHSOCIAL_TOKEN,
+      )
+
+      while True:
+        started = time.time()
+        try:
+          since_id = get_state(conn, "last_seen_id")
+          posts = fetch_new_posts(api, since_id)
+          bootstrap_cursor(conn, posts)
+
+          if since_id is None:
+            log("heartbeat: bootstrap run")
+          elif not posts:
+            log("heartbeat: no new posts")
+          else:
+            for post in posts:
+              delivery_id = post_webhook(post)
+              mark_delivery(conn, delivery_id, post["id"], "sent")
+              set_state(conn, "last_seen_id", post["id"])
+              log(f"delivered post {post['id']}")
+        except urllib.error.HTTPError as err:
+          log(f"poll error: HTTP {err.code}")
+        except urllib.error.URLError as err:
+          log(f"poll error: {err}")
+        except Exception as err:
+          log(f"poll error: {err}")
+
+        elapsed = time.time() - started
+        sleep_for = max(POLL_SECONDS - elapsed, 1)
+        time.sleep(sleep_for)
+
+
+    if __name__ == "__main__":
+      main_loop()
+EOF
+
+log "Applying PersistentVolumeClaim (${PVC_NAME}) and Deployment (${NAME})"
+cat << EOF | k apply -n "${NAMESPACE}" -f -
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ${PVC_NAME}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: ${STATE_SIZE}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${NAME}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ${NAME}
+  template:
+    metadata:
+      labels:
+        app: ${NAME}
+    spec:
+      containers:
+        - name: poller
+          image: ${IMAGE}
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-lc"]
+          args:
+            - pip install --no-cache-dir truthbrush && exec python3 /app/poller.py
+          env:
+            - name: TARGET_HANDLE
+              value: "${TARGET_HANDLE}"
+            - name: POLL_SECONDS
+              value: "${POLL_SECONDS}"
+            - name: DB_PATH
+              value: "/data/state.db"
+            - name: HTTP_TIMEOUT_SECONDS
+              value: "${TIMEOUT_SECONDS:-15}"
+            - name: WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: ${SECRET_NAME}
+                  key: webhook-url
+            - name: WEBHOOK_BEARER
+              valueFrom:
+                secretKeyRef:
+                  name: ${SECRET_NAME}
+                  key: webhook-bearer
+            - name: WEBHOOK_SIGNING_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: ${SECRET_NAME}
+                  key: webhook-signing-key
+            - name: TRUTHSOCIAL_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: ${SECRET_NAME}
+                  key: truthsocial-token
+                  optional: true
+            - name: TRUTHSOCIAL_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: ${SECRET_NAME}
+                  key: truthsocial-username
+                  optional: true
+            - name: TRUTHSOCIAL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ${SECRET_NAME}
+                  key: truthsocial-password
+                  optional: true
+          volumeMounts:
+            - name: script
+              mountPath: /app
+            - name: state
+              mountPath: /data
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+      volumes:
+        - name: script
+          configMap:
+            name: ${CONFIGMAP_NAME}
+            defaultMode: 0755
+        - name: state
+          persistentVolumeClaim:
+            claimName: ${PVC_NAME}
+EOF
+
+log "Waiting for rollout to complete"
+k rollout status deployment/"${NAME}" -n "${NAMESPACE}" --timeout=3m
+
+echo
+log "truthbrush-poller installed successfully"
+echo "Namespace:      ${NAMESPACE}"
+echo "Deployment:     ${NAME}"
+echo "Target handle:  ${TARGET_HANDLE}"
+echo "Poll interval:  ${POLL_SECONDS}s"
+echo "Webhook:        configured via Secret ${SECRET_NAME}"
+echo
+echo "Useful commands:"
+echo "  kubectl logs -n ${NAMESPACE} deploy/${NAME} -f"
+echo "  kubectl get pods -n ${NAMESPACE} -l app=${NAME}"
+echo#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# shellcheck disable=SC1091
+source "${SCRIPTS_DIR}/lib/common.sh"
+# shellcheck disable=SC1091
+source "${SCRIPTS_DIR}/recipes/lib.sh"
+
+usage() {
+  cat << 'EOF'
+Deploy a low-latency Truth poller as a Kubernetes Deployment.
+
+The poller uses Truthbrush (Truth Social API client), stores minimal state in
+SQLite, and forwards only new posts to an OpenClaw webhook.
+
+Usage:
+  netcup-kube install truthbrush-poller [options]
+
+Options:
+  --namespace <name>            Namespace to install into (default: openclaw).
+  --name <name>                 Base name for Deployment/ConfigMap/Secret/PVC (default: truthbrush-poller).
+  --secret-name <name>          Secret name for credentials/webhook config (default: <name>-secrets).
+  --image <image>               Container image (default: python:3.12-slim).
+  --target-handle <handle>      Truth Social account to poll (default: realDonaldTrump).
+  --poll-seconds <seconds>      Poll interval in seconds (default: 20).
+  --use-existing-secret         Use an existing Kubernetes Secret instead of creating/updating one.
+  --webhook-url <url>           OpenClaw webhook endpoint URL (required unless --uninstall).
+  --webhook-bearer <token>      Optional bearer token sent as Authorization header.
+  --webhook-signing-key <key>   Optional HMAC signing key for X-Truthbrush-Signature.
+  --truthsocial-token <token>   Truth Social auth token for Truthbrush.
+  --truthsocial-username <name> Truth Social username for Truthbrush login.
+  --truthsocial-password <pass> Truth Social password for Truthbrush login.
+  --state-size <size>           PVC size for SQLite state (default: 1Gi).
+  --delete-secret               Also delete Secret during --uninstall.
+  --uninstall                   Uninstall poller resources.
+  -h, --help                    Show this help.
+
+Environment:
+  KUBECONFIG                    Kubeconfig to use. If not set, defaults to /etc/rancher/k3s/k3s.yaml (on the node).
+  TRUTHBRUSH_NAMESPACE          Alternative to --namespace.
+  TRUTHBRUSH_NAME               Alternative to --name.
+  TRUTHBRUSH_SECRET_NAME        Alternative to --secret-name.
+  TRUTHBRUSH_IMAGE              Alternative to --image.
+  TRUTHBRUSH_TARGET_HANDLE      Alternative to --target-handle.
+  TRUTHBRUSH_POLL_SECONDS       Alternative to --poll-seconds.
+  TRUTHBRUSH_USE_EXISTING_SECRET true|false (default: false).
+  OPENCLAW_WEBHOOK_URL          Alternative to --webhook-url.
+  OPENCLAW_WEBHOOK_BEARER       Alternative to --webhook-bearer.
+  OPENCLAW_WEBHOOK_SIGNING_KEY  Alternative to --webhook-signing-key.
+  TRUTHSOCIAL_TOKEN             Alternative to --truthsocial-token.
+  TRUTHSOCIAL_USERNAME          Alternative to --truthsocial-username.
+  TRUTHSOCIAL_PASSWORD          Alternative to --truthsocial-password.
+  TRUTHBRUSH_STATE_SIZE         Alternative to --state-size.
+  TRUTHBRUSH_DELETE_SECRET      true|false (default: false).
+  CONFIRM=true                  Required for non-interactive --uninstall.
+
+Notes:
+  - This recipe is idempotent (kubectl apply based).
+  - Secrets are stored in a Kubernetes Secret and never printed.
+  - Truthbrush source auth must be provided via Secret keys (token or username/password).
+  - The payload includes an idempotency key and post metadata.
+EOF
+}
+
+NAMESPACE="${TRUTHBRUSH_NAMESPACE:-${NAMESPACE_OPENCLAW}}"
+NAME="${TRUTHBRUSH_NAME:-truthbrush-poller}"
+SECRET_NAME="${TRUTHBRUSH_SECRET_NAME:-}"
+IMAGE="${TRUTHBRUSH_IMAGE:-python:3.12-slim}"
+TARGET_HANDLE="${TRUTHBRUSH_TARGET_HANDLE:-realDonaldTrump}"
+POLL_SECONDS="${TRUTHBRUSH_POLL_SECONDS:-20}"
+USE_EXISTING_SECRET="${TRUTHBRUSH_USE_EXISTING_SECRET:-false}"
+WEBHOOK_URL="${OPENCLAW_WEBHOOK_URL:-}"
+WEBHOOK_BEARER="${OPENCLAW_WEBHOOK_BEARER:-}"
+WEBHOOK_SIGNING_KEY="${OPENCLAW_WEBHOOK_SIGNING_KEY:-}"
+TRUTHSOCIAL_TOKEN="${TRUTHSOCIAL_TOKEN:-}"
+TRUTHSOCIAL_USERNAME="${TRUTHSOCIAL_USERNAME:-}"
+TRUTHSOCIAL_PASSWORD="${TRUTHSOCIAL_PASSWORD:-}"
+STATE_SIZE="${TRUTHBRUSH_STATE_SIZE:-1Gi}"
+DELETE_SECRET="${TRUTHBRUSH_DELETE_SECRET:-false}"
+UNINSTALL="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --namespace)
+      shift
+      NAMESPACE="${1:-}"
+      ;;
+    --namespace=*)
+      NAMESPACE="${1#*=}"
+      ;;
+    --name)
+      shift
+      NAME="${1:-}"
+      ;;
+    --name=*)
+      NAME="${1#*=}"
+      ;;
+    --secret-name)
+      shift
+      SECRET_NAME="${1:-}"
+      ;;
+    --secret-name=*)
+      SECRET_NAME="${1#*=}"
+      ;;
+    --image)
+      shift
+      IMAGE="${1:-}"
+      ;;
+    --image=*)
+      IMAGE="${1#*=}"
+      ;;
+    --target-handle)
+      shift
+      TARGET_HANDLE="${1:-}"
+      ;;
+    --target-handle=*)
+      TARGET_HANDLE="${1#*=}"
+      ;;
+    --poll-seconds)
+      shift
+      POLL_SECONDS="${1:-}"
+      ;;
+    --poll-seconds=*)
+      POLL_SECONDS="${1#*=}"
+      ;;
+    --use-existing-secret)
+      USE_EXISTING_SECRET="true"
+      ;;
+    --webhook-url)
+      shift
+      WEBHOOK_URL="${1:-}"
+      ;;
+    --webhook-url=*)
+      WEBHOOK_URL="${1#*=}"
+      ;;
+    --webhook-bearer)
+      shift
+      WEBHOOK_BEARER="${1:-}"
+      ;;
+    --webhook-bearer=*)
+      WEBHOOK_BEARER="${1#*=}"
+      ;;
+    --webhook-signing-key)
+      shift
+      WEBHOOK_SIGNING_KEY="${1:-}"
+      ;;
+    --webhook-signing-key=*)
+      WEBHOOK_SIGNING_KEY="${1#*=}"
+      ;;
+    --truthsocial-token)
+      shift
+      TRUTHSOCIAL_TOKEN="${1:-}"
+      ;;
+    --truthsocial-token=*)
+      TRUTHSOCIAL_TOKEN="${1#*=}"
+      ;;
+    --truthsocial-username)
+      shift
+      TRUTHSOCIAL_USERNAME="${1:-}"
+      ;;
+    --truthsocial-username=*)
+      TRUTHSOCIAL_USERNAME="${1#*=}"
+      ;;
+    --truthsocial-password)
+      shift
+      TRUTHSOCIAL_PASSWORD="${1:-}"
+      ;;
+    --truthsocial-password=*)
+      TRUTHSOCIAL_PASSWORD="${1#*=}"
+      ;;
+    --state-size)
+      shift
+      STATE_SIZE="${1:-}"
+      ;;
+    --state-size=*)
+      STATE_SIZE="${1#*=}"
+      ;;
+    --delete-secret)
+      DELETE_SECRET="true"
+      ;;
+    --uninstall)
+      UNINSTALL="true"
+      ;;
+    -h | --help | help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+  shift || true
+done
+
+[[ -n "${NAMESPACE}" ]] || die "Namespace is required"
+[[ -n "${NAME}" ]] || die "Name is required"
+if [[ -z "${SECRET_NAME}" ]]; then
+  SECRET_NAME="${NAME}-secrets"
+fi
+[[ -n "${IMAGE}" ]] || die "Image is required"
+[[ -n "${TARGET_HANDLE}" ]] || die "Target handle is required"
+[[ -n "${POLL_SECONDS}" ]] || die "Poll seconds is required"
+[[ "${POLL_SECONDS}" =~ ^[0-9]+$ ]] || die "Poll seconds must be an integer"
+((POLL_SECONDS > 0)) || die "Poll seconds must be > 0"
+USE_EXISTING_SECRET="$(bool_norm "${USE_EXISTING_SECRET}")"
+DELETE_SECRET="$(bool_norm "${DELETE_SECRET}")"
+
+CONFIGMAP_NAME="${NAME}-script"
+PVC_NAME="${NAME}-state"
+
+if [[ "${UNINSTALL}" == "true" ]]; then
+  recipe_confirm_or_die "Uninstall truthbrush-poller (${NAME}) from namespace ${NAMESPACE}"
+  log "Uninstalling truthbrush-poller resources from namespace: ${NAMESPACE}"
+  recipe_kdelete deployment "${NAME}" -n "${NAMESPACE}"
+  recipe_kdelete configmap "${CONFIGMAP_NAME}" -n "${NAMESPACE}"
+  if [[ "${DELETE_SECRET}" == "true" ]]; then
+    recipe_kdelete secret "${SECRET_NAME}" -n "${NAMESPACE}"
+  fi
+  recipe_kdelete pvc "${PVC_NAME}" -n "${NAMESPACE}"
+  log "Uninstall requested. Note: data may persist if the storage class retains volumes."
+  exit 0
+fi
+
+log "Installing truthbrush-poller into namespace: ${NAMESPACE}"
+recipe_ensure_namespace "${NAMESPACE}"
+
+if [[ "${USE_EXISTING_SECRET}" == "true" ]]; then
+  log "Using existing Kubernetes Secret (${SECRET_NAME})"
+  k get secret "${SECRET_NAME}" -n "${NAMESPACE}" > /dev/null
+else
+  [[ -n "${WEBHOOK_URL}" ]] || die "--webhook-url (or OPENCLAW_WEBHOOK_URL) is required when creating secret"
+  if [[ -z "${TRUTHSOCIAL_TOKEN}" ]]; then
+    [[ -n "${TRUTHSOCIAL_USERNAME}" ]] || die "Provide TRUTHSOCIAL_TOKEN or TRUTHSOCIAL_USERNAME+TRUTHSOCIAL_PASSWORD"
+    [[ -n "${TRUTHSOCIAL_PASSWORD}" ]] || die "Provide TRUTHSOCIAL_TOKEN or TRUTHSOCIAL_USERNAME+TRUTHSOCIAL_PASSWORD"
+  fi
+
+  log "Applying Kubernetes Secret (${SECRET_NAME})"
+  k create secret generic "${SECRET_NAME}" \
+    -n "${NAMESPACE}" \
+    --from-literal=webhook-url="${WEBHOOK_URL}" \
+    --from-literal=webhook-bearer="${WEBHOOK_BEARER}" \
+    --from-literal=webhook-signing-key="${WEBHOOK_SIGNING_KEY}" \
+    --from-literal=truthsocial-token="${TRUTHSOCIAL_TOKEN}" \
+    --from-literal=truthsocial-username="${TRUTHSOCIAL_USERNAME}" \
+    --from-literal=truthsocial-password="${TRUTHSOCIAL_PASSWORD}" \
+    --dry-run=client -o yaml | k apply -f -
+fi
+
+log "Applying ConfigMap (${CONFIGMAP_NAME})"
+cat << EOF | k apply -n "${NAMESPACE}" -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ${CONFIGMAP_NAME}
+data:
+  poller.py: |
+    #!/usr/bin/env python3
+    import datetime
+    import hashlib
+    import hmac
+    import json
+    import os
+    import sqlite3
+    import time
+    from html import unescape
+    import urllib.error
+    import urllib.request
+
+    from truthbrush import Api
+
+    TARGET_HANDLE = os.environ.get("TARGET_HANDLE", "realDonaldTrump").strip()
+    WEBHOOK_URL = os.environ.get("WEBHOOK_URL", "").strip()
+    WEBHOOK_BEARER = os.environ.get("WEBHOOK_BEARER", "").strip()
+    WEBHOOK_SIGNING_KEY = os.environ.get("WEBHOOK_SIGNING_KEY", "").strip()
+    TRUTHSOCIAL_TOKEN = os.environ.get("TRUTHSOCIAL_TOKEN", "").strip() or None
+    TRUTHSOCIAL_USERNAME = os.environ.get("TRUTHSOCIAL_USERNAME", "").strip() or None
+    TRUTHSOCIAL_PASSWORD = os.environ.get("TRUTHSOCIAL_PASSWORD", "").strip() or None
+    POLL_SECONDS = int(os.environ.get("POLL_SECONDS", "20"))
+    DB_PATH = os.environ.get("DB_PATH", "/data/state.db")
+    TIMEOUT_SECONDS = int(os.environ.get("HTTP_TIMEOUT_SECONDS", "15"))
+
+
+    def log(msg):
+      now = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+      print(f"[{now}] {msg}", flush=True)
+
+
+    def clean_content(html_text):
+      text = unescape(str(html_text or ""))
+      text = text.replace("<br>", " ").replace("<br/>", " ").replace("<br />", " ")
+      while "<" in text and ">" in text:
+        start = text.find("<")
+        end = text.find(">", start)
+        if end == -1:
+          break
+        text = text[:start] + " " + text[end + 1 :]
+      return " ".join(text.split())
+
+
+    def db_connect():
+      os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
+      conn = sqlite3.connect(DB_PATH)
+      conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS state (
+          key TEXT PRIMARY KEY,
+          value TEXT NOT NULL
+        )
+        """
+      )
+      conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS deliveries (
+          idempotency_key TEXT PRIMARY KEY,
+          post_id TEXT NOT NULL,
+          delivered_at TEXT NOT NULL,
+          status TEXT NOT NULL
+        )
+        """
+      )
+      conn.commit()
+      return conn
+
+
+    def get_state(conn, key):
+      row = conn.execute("SELECT value FROM state WHERE key = ?", (key,)).fetchone()
+      return row[0] if row else None
+
+
+    def set_state(conn, key, value):
+      conn.execute(
+        "INSERT OR REPLACE INTO state (key, value) VALUES (?, ?)",
+        (key, value),
+      )
+      conn.commit()
+
+
+    def mark_delivery(conn, idempotency_key, post_id, status):
+      ts = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+      conn.execute(
+        "INSERT OR REPLACE INTO deliveries (idempotency_key, post_id, delivered_at, status) VALUES (?, ?, ?, ?)",
+        (idempotency_key, post_id, ts, status),
+      )
+      conn.commit()
+
+
+    def signature_for(body):
+      if not WEBHOOK_SIGNING_KEY:
+        return ""
+      digest = hmac.new(
+        WEBHOOK_SIGNING_KEY.encode("utf-8"),
+        body,
+        hashlib.sha256,
+      ).hexdigest()
+      return f"sha256={digest}"
+
+
+    def post_webhook(post):
+      idempotency_key = f"truthsocial:{post['id']}"
+      payload = {
+        "source": "truthbrush-poller",
+        "event": "truthsocial.new_post",
+        "generatedAt": datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "idempotencyKey": idempotency_key,
+        "post": post,
+      }
+      body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+
+      headers = {
+        "Content-Type": "application/json",
+        "X-Idempotency-Key": idempotency_key,
+        "X-Truthbrush-Event": "truthsocial.new_post",
+      }
+      if WEBHOOK_BEARER:
+        headers["Authorization"] = f"Bearer {WEBHOOK_BEARER}"
+
+      sig = signature_for(body)
+      if sig:
+        headers["X-Truthbrush-Signature"] = sig
+
+      req = urllib.request.Request(WEBHOOK_URL, data=body, headers=headers, method="POST")
+      with urllib.request.urlopen(req, timeout=TIMEOUT_SECONDS) as res:
+        status = getattr(res, "status", 200)
+        if status < 200 or status >= 300:
+          raise RuntimeError(f"webhook returned status {status}")
+      return idempotency_key
+
+
+    def normalize_post(raw_post):
+      post_id = str(raw_post.get("id", "")).strip()
+      if not post_id:
+        return None
+      return {
+        "id": post_id,
+        "url": raw_post.get("url") or "",
+        "createdAt": raw_post.get("created_at") or "",
+        "content": clean_content(raw_post.get("content") or ""),
+      }
+
+
+    def fetch_new_posts(api, since_id):
+      posts = list(api.pull_statuses(username=TARGET_HANDLE, replies=False, since_id=since_id, verbose=False))
+      normalized = []
+      for post in posts:
+        candidate = normalize_post(post)
+        if candidate is not None:
+          normalized.append(candidate)
+      normalized.sort(key=lambda p: int(p["id"]))
+      return normalized
+
+
+    def bootstrap_cursor(conn, posts):
+      last_seen_id = get_state(conn, "last_seen_id")
+      if last_seen_id is not None:
+        return
+      if not posts:
+        return
+      latest = max(posts, key=lambda p: int(p["id"]))
+      set_state(conn, "last_seen_id", latest["id"])
+      log(f"bootstrapped cursor at {latest['id']}; waiting for fresh posts")
+
+
+    def main_loop():
+      if not WEBHOOK_URL:
+        raise RuntimeError("WEBHOOK_URL is required")
+      if TRUTHSOCIAL_TOKEN is None and (TRUTHSOCIAL_USERNAME is None or TRUTHSOCIAL_PASSWORD is None):
+        raise RuntimeError("Truth Social credentials missing (set TRUTHSOCIAL_TOKEN or TRUTHSOCIAL_USERNAME+TRUTHSOCIAL_PASSWORD)")
+
+      conn = db_connect()
+      api = Api(
+        username=TRUTHSOCIAL_USERNAME,
+        password=TRUTHSOCIAL_PASSWORD,
+        token=TRUTHSOCIAL_TOKEN,
+      )
+
+      while True:
+        started = time.time()
+        try:
+          since_id = get_state(conn, "last_seen_id")
+          posts = fetch_new_posts(api, since_id)
+          bootstrap_cursor(conn, posts)
+
+          if since_id is None:
+            log("heartbeat: bootstrap run")
+          elif not posts:
+            log("heartbeat: no new posts")
+          else:
+            for post in posts:
+              delivery_id = post_webhook(post)
+              mark_delivery(conn, delivery_id, post["id"], "sent")
+              set_state(conn, "last_seen_id", post["id"])
+              log(f"delivered post {post['id']}")
+        except urllib.error.HTTPError as err:
+          log(f"poll error: HTTP {err.code}")
+        except urllib.error.URLError as err:
+          log(f"poll error: {err}")
+        except Exception as err:
+          log(f"poll error: {err}")
+
+        elapsed = time.time() - started
+        sleep_for = max(POLL_SECONDS - elapsed, 1)
+        time.sleep(sleep_for)
+
+
+    if __name__ == "__main__":
+      main_loop()
+EOF
+
+log "Applying PersistentVolumeClaim (${PVC_NAME}) and Deployment (${NAME})"
+cat << EOF | k apply -n "${NAMESPACE}" -f -
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ${PVC_NAME}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: ${STATE_SIZE}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${NAME}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ${NAME}
+  template:
+    metadata:
+      labels:
+        app: ${NAME}
+    spec:
+      containers:
+        - name: poller
+          image: ${IMAGE}
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-lc"]
+          args:
+            - pip install --no-cache-dir truthbrush && exec python3 /app/poller.py
+          env:
+            - name: TARGET_HANDLE
+              value: "${TARGET_HANDLE}"
+            - name: POLL_SECONDS
+              value: "${POLL_SECONDS}"
+            - name: DB_PATH
+              value: "/data/state.db"
+            - name: HTTP_TIMEOUT_SECONDS
+              value: "${TIMEOUT_SECONDS:-15}"
+            - name: WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: ${SECRET_NAME}
+                  key: webhook-url
+            - name: WEBHOOK_BEARER
+              valueFrom:
+                secretKeyRef:
+                  name: ${SECRET_NAME}
+                  key: webhook-bearer
+            - name: WEBHOOK_SIGNING_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: ${SECRET_NAME}
+                  key: webhook-signing-key
+            - name: TRUTHSOCIAL_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: ${SECRET_NAME}
+                  key: truthsocial-token
+                  optional: true
+            - name: TRUTHSOCIAL_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: ${SECRET_NAME}
+                  key: truthsocial-username
+                  optional: true
+            - name: TRUTHSOCIAL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ${SECRET_NAME}
+                  key: truthsocial-password
+                  optional: true
+          volumeMounts:
+            - name: script
+              mountPath: /app
+            - name: state
+              mountPath: /data
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+      volumes:
+        - name: script
+          configMap:
+            name: ${CONFIGMAP_NAME}
+            defaultMode: 0755
+        - name: state
+          persistentVolumeClaim:
+            claimName: ${PVC_NAME}
+EOF
+
+log "Waiting for rollout to complete"
+k rollout status deployment/"${NAME}" -n "${NAMESPACE}" --timeout=3m
+
+echo
+log "truthbrush-poller installed successfully"
+echo "Namespace:      ${NAMESPACE}"
+echo "Deployment:     ${NAME}"
+echo "Target handle:  ${TARGET_HANDLE}"
+echo "Poll interval:  ${POLL_SECONDS}s"
+echo "Webhook:        configured via Secret ${SECRET_NAME}"
+echo
+echo "Useful commands:"
+echo "  kubectl logs -n ${NAMESPACE} deploy/${NAME} -f"
+echo "  kubectl get pods -n ${NAMESPACE} -l app=${NAME}"
+echo

--- a/scripts/recipes/vscode-copilot-proxy/README.md
+++ b/scripts/recipes/vscode-copilot-proxy/README.md
@@ -1,0 +1,66 @@
+# vscode-copilot-proxy recipe
+
+Installs an internal-only OpenVSCode Server instance for running a Copilot-proxy-capable VS Code extension.
+
+## What it creates
+
+- `Deployment/<release>` with `gitpod/openvscode-server`
+- `Service/<release>` as `ClusterIP` on port `3000`
+- `PersistentVolumeClaim/<release>-data` for VS Code state/extensions
+- `NetworkPolicy/<release>-internal` allowing ingress only from pods
+- Init-container bootstrap that auto-installs proxy extension candidates
+- Init-container best-effort bootstrap of official Copilot CLI (`@github/copilot`)
+
+Default release name is `vscode-copilot-proxy` in namespace `platform`.
+
+## Install
+
+```bash
+netcup-kube install vscode-copilot-proxy
+```
+
+Turnkey install with strict extension bootstrap (default behavior):
+
+- Installer fails if it cannot install any extension candidate.
+- Default candidates:
+  - `suhaibbinyounis.github-copilot-api-vscode`
+  - `ryonakae.vscode-lm-proxy`
+  - `lewiswigmore.open-wire`
+
+Optional deterministic VSIX source:
+
+```bash
+netcup-kube install vscode-copilot-proxy \
+  --namespace openclaw \
+  --vsix-url "https://example.com/your-proxy-extension.vsix"
+```
+
+Custom namespace/release:
+
+```bash
+netcup-kube install vscode-copilot-proxy --namespace openclaw --release vscode-copilot-proxy
+```
+
+## Connectivity model
+
+- No Ingress, NodePort, or LoadBalancer is created.
+- Service is reachable only via cluster networking:
+  - `http://<release>.<namespace>.svc.cluster.local:3000`
+- Use this as OpenClaw Copilot Proxy base URL (must include `/v1`):
+  - `http://<release>.<namespace>.svc.cluster.local:3030/v1`
+
+## Auth and `/v1` readiness
+
+- Official CLI auth can run in the pod via `copilot` (installed best-effort by this recipe).
+- CLI authentication alone is not sufficient for OpenClaw provider traffic.
+- OpenClaw requires an extension/service in this VS Code instance that serves OpenAI-compatible `/v1` routes.
+- In OpenVSCode, start the proxy gateway and bind it to `0.0.0.0:3030` so other pods can reach it.
+
+## Optional local access for setup
+
+```bash
+kubectl -n <namespace> port-forward svc/<release> 3000:3000
+```
+
+Then open `http://localhost:3000` only if you want to inspect/configure the VS Code instance.
+No public exposure is created by this recipe.

--- a/scripts/recipes/vscode-copilot-proxy/install.sh
+++ b/scripts/recipes/vscode-copilot-proxy/install.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPTS_DIR}/lib/common.sh"
+# shellcheck disable=SC1091
+source "${SCRIPTS_DIR}/recipes/lib.sh"
+
+usage() {
+  cat << 'EOF'
+Install an internal-only OpenVSCode Server instance for Copilot Proxy workflows.
+
+Usage:
+  netcup-kube install vscode-copilot-proxy [options]
+
+Options:
+  --namespace <name>      Namespace to install into (default: platform).
+  --release <name>        Resource base name (default: vscode-copilot-proxy).
+  --image <ref>           OpenVSCode Server image (default: gitpod/openvscode-server:latest).
+  --storage <size>        PVC size for VS Code state/extensions (default: 10Gi).
+  --extensions <list>     Comma-separated extension IDs to try (default: common Copilot proxy API extensions).
+  --vsix-url <url>        Optional VSIX URL; attempted first.
+  --allow-missing-extension
+                          Continue deployment when extension bootstrap fails (default: false).
+  --uninstall             Remove deployment/service/networkpolicy/pvc.
+  -h, --help              Show this help.
+
+Environment:
+  KUBECONFIG              Kubeconfig to use.
+
+Notes:
+  - This recipe creates only an internal ClusterIP service (no Ingress/NodePort/LoadBalancer).
+  - NetworkPolicy allows ingress only from pods (all namespaces).
+  - Recipe bootstraps a Copilot-proxy-capable extension on startup.
+  - Recipe also attempts to install the official Copilot CLI (`@github/copilot`) in the pod.
+  - Intended use: run Copilot Proxy extension in this VS Code instance and point OpenClaw provider
+    base URL to: http://<release>.<namespace>.svc.cluster.local:3030/v1
+EOF
+}
+
+NAMESPACE="${NAMESPACE_PLATFORM}"
+RELEASE="vscode-copilot-proxy"
+IMAGE="gitpod/openvscode-server:latest"
+STORAGE="10Gi"
+EXTENSIONS="${VSCODE_COPILOT_PROXY_EXTENSIONS:-suhaibbinyounis.github-copilot-api-vscode,ryonakae.vscode-lm-proxy,lewiswigmore.open-wire}"
+VSIX_URL="${VSCODE_COPILOT_PROXY_VSIX_URL:-}"
+ALLOW_MISSING_EXTENSION="${VSCODE_COPILOT_PROXY_ALLOW_MISSING_EXTENSION:-false}"
+UNINSTALL="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --namespace)
+      shift
+      NAMESPACE="${1:-}"
+      ;;
+    --namespace=*)
+      NAMESPACE="${1#*=}"
+      ;;
+    --release)
+      shift
+      RELEASE="${1:-}"
+      ;;
+    --release=*)
+      RELEASE="${1#*=}"
+      ;;
+    --image)
+      shift
+      IMAGE="${1:-}"
+      ;;
+    --image=*)
+      IMAGE="${1#*=}"
+      ;;
+    --storage)
+      shift
+      STORAGE="${1:-}"
+      ;;
+    --storage=*)
+      STORAGE="${1#*=}"
+      ;;
+    --extensions)
+      shift
+      EXTENSIONS="${1:-}"
+      ;;
+    --extensions=*)
+      EXTENSIONS="${1#*=}"
+      ;;
+    --vsix-url)
+      shift
+      VSIX_URL="${1:-}"
+      ;;
+    --vsix-url=*)
+      VSIX_URL="${1#*=}"
+      ;;
+    --allow-missing-extension)
+      ALLOW_MISSING_EXTENSION="true"
+      ;;
+    --uninstall)
+      UNINSTALL="true"
+      ;;
+    -h | --help | help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+  shift || true
+done
+
+[[ -n "${NAMESPACE}" ]] || die "Namespace is required"
+[[ -n "${RELEASE}" ]] || die "Release name is required"
+[[ -n "${IMAGE}" ]] || die "Image is required"
+[[ -n "${STORAGE}" ]] || die "Storage size is required"
+ALLOW_MISSING_EXTENSION="$(bool_norm "${ALLOW_MISSING_EXTENSION}")"
+
+MANIFEST_TEMPLATE="${SCRIPT_DIR}/manifests.yaml"
+[[ -f "${MANIFEST_TEMPLATE}" ]] || die "Missing manifest template: ${MANIFEST_TEMPLATE}"
+
+escape_sed_replacement() {
+  printf '%s' "$1" | sed -e 's/[\\&|]/\\\\&/g'
+}
+
+render_manifest() {
+  local out_file="$1"
+  local namespace_esc release_esc image_esc storage_esc
+  local extensions_esc vsix_url_esc allow_missing_extension_esc
+
+  namespace_esc="$(escape_sed_replacement "${NAMESPACE}")"
+  release_esc="$(escape_sed_replacement "${RELEASE}")"
+  image_esc="$(escape_sed_replacement "${IMAGE}")"
+  storage_esc="$(escape_sed_replacement "${STORAGE}")"
+  extensions_esc="$(escape_sed_replacement "${EXTENSIONS}")"
+  vsix_url_esc="$(escape_sed_replacement "${VSIX_URL}")"
+  allow_missing_extension_esc="$(escape_sed_replacement "${ALLOW_MISSING_EXTENSION}")"
+
+  sed \
+    -e "s|__NAMESPACE__|${namespace_esc}|g" \
+    -e "s|__RELEASE__|${release_esc}|g" \
+    -e "s|__IMAGE__|${image_esc}|g" \
+    -e "s|__STORAGE__|${storage_esc}|g" \
+    -e "s|__EXTENSIONS__|${extensions_esc}|g" \
+    -e "s|__VSIX_URL__|${vsix_url_esc}|g" \
+    -e "s|__ALLOW_MISSING_EXTENSION__|${allow_missing_extension_esc}|g" \
+    "${MANIFEST_TEMPLATE}" > "${out_file}"
+}
+
+if [[ "${UNINSTALL}" == "true" ]]; then
+  recipe_confirm_or_die "Uninstall ${RELEASE} from namespace ${NAMESPACE}"
+  recipe_kdelete -n "${NAMESPACE}" deployment "${RELEASE}"
+  recipe_kdelete -n "${NAMESPACE}" service "${RELEASE}"
+  recipe_kdelete -n "${NAMESPACE}" networkpolicy "${RELEASE}-internal"
+  recipe_kdelete -n "${NAMESPACE}" pvc "${RELEASE}-data"
+  log "Uninstall requested for ${RELEASE}."
+  exit 0
+fi
+
+log "Installing ${RELEASE} into namespace: ${NAMESPACE}"
+recipe_ensure_namespace "${NAMESPACE}"
+
+rendered_manifest="$(mktemp -t vscode-copilot-proxy.XXXXXX.yaml)"
+trap 'rm -f "${rendered_manifest}"' EXIT
+render_manifest "${rendered_manifest}"
+
+k apply -f "${rendered_manifest}"
+
+run k -n "${NAMESPACE}" rollout status deployment/"${RELEASE}" --timeout=5m
+
+cat << EOF
+
+${RELEASE} installed.
+
+Internal URL (pod-to-pod):
+  http://${RELEASE}.${NAMESPACE}.svc.cluster.local:3000
+
+Copilot Proxy provider base URL for OpenClaw:
+  http://${RELEASE}.${NAMESPACE}.svc.cluster.local:3030/v1
+
+Local setup (optional):
+  kubectl -n ${NAMESPACE} port-forward svc/${RELEASE} 3000:3000
+
+Recipe bootstrap installs proxy extension candidates automatically.
+Recipe also attempts to install official Copilot CLI ('@github/copilot') for in-pod auth flows.
+Important: CLI auth alone does not expose OpenAI-compatible '/v1' endpoints.
+OpenClaw needs a running proxy extension/service that serves '/v1'.
+In OpenVSCode, start the gateway and set network binding to 0.0.0.0:3030.
+
+If your preferred extension is not in the defaults, re-run with:
+  --vsix-url <url> or --extensions <publisher.extension,...>
+EOF

--- a/scripts/recipes/vscode-copilot-proxy/manifests.yaml
+++ b/scripts/recipes/vscode-copilot-proxy/manifests.yaml
@@ -1,0 +1,260 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: __RELEASE__-data
+  namespace: __NAMESPACE__
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: __STORAGE__
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: __RELEASE__
+  namespace: __NAMESPACE__
+  labels:
+    app.kubernetes.io/name: __RELEASE__
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: __RELEASE__
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: __RELEASE__
+    spec:
+      initContainers:
+        - name: bootstrap-proxy-extension
+          image: __IMAGE__
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: EXTENSIONS
+              value: "__EXTENSIONS__"
+            - name: VSIX_URL
+              value: "__VSIX_URL__"
+            - name: ALLOW_MISSING_EXTENSION
+              value: "__ALLOW_MISSING_EXTENSION__"
+          command:
+            - /bin/sh
+            - -lc
+          args:
+            - |
+              set -eu
+
+              EXT_DIR="/var/lib/openvscode/extensions"
+              DATA_DIR="/var/lib/openvscode/data"
+              TOOLS_DIR="/var/lib/openvscode/tools"
+              BIN_DIR="/var/lib/openvscode/bin"
+              mkdir -p "${EXT_DIR}" "${DATA_DIR}/Machine"
+              mkdir -p "${TOOLS_DIR}" "${BIN_DIR}"
+
+              install_extension() {
+                ext="${1}"
+                if command -v openvscode-server > /dev/null 2>&1; then
+                  openvscode-server --install-extension "${ext}" --extensions-dir "${EXT_DIR}" --user-data-dir "${DATA_DIR}" > /tmp/extension-install.log 2>&1
+                  return $?
+                fi
+                /home/.openvscode-server/bin/openvscode-server --install-extension "${ext}" --extensions-dir "${EXT_DIR}" --user-data-dir "${DATA_DIR}" > /tmp/extension-install.log 2>&1
+              }
+
+              installed="false"
+
+              if [ -n "${VSIX_URL}" ] && command -v curl > /dev/null 2>&1; then
+                if curl -fsSL "${VSIX_URL}" -o /tmp/copilot-proxy.vsix && install_extension /tmp/copilot-proxy.vsix; then
+                  installed="true"
+                fi
+              fi
+
+              if [ "${installed}" != "true" ]; then
+                old_ifs="${IFS}"
+                IFS=','
+                for ext in ${EXTENSIONS}; do
+                  ext_trimmed="$(echo "${ext}" | sed 's/^ *//;s/ *$//')"
+                  [ -n "${ext_trimmed}" ] || continue
+                  if install_extension "${ext_trimmed}"; then
+                    installed="true"
+                    break
+                  fi
+                done
+                IFS="${old_ifs}"
+              fi
+
+              if [ "${installed}" != "true" ]; then
+                echo "WARNING: No Copilot-proxy extension could be installed." >&2
+                if [ "${ALLOW_MISSING_EXTENSION}" != "true" ]; then
+                  echo "Set --allow-missing-extension to continue without extension bootstrap." >&2
+                  echo "Installer log follows:" >&2
+                  cat /tmp/extension-install.log >&2 || true
+                  exit 1
+                fi
+              fi
+
+              install_official_copilot_cli() {
+                rm -f "${BIN_DIR}/copilot"
+
+                node_bin=""
+                if command -v node > /dev/null 2>&1; then
+                  node_bin="$(command -v node)"
+                elif [ -x /home/.openvscode-server/node ]; then
+                  node_bin="/home/.openvscode-server/node"
+                fi
+
+                if [ -z "${node_bin}" ]; then
+                  echo "WARNING: could not find node binary to install @github/copilot CLI." >&2
+                  return 0
+                fi
+
+                npm_cli=""
+                if command -v npm > /dev/null 2>&1; then
+                  npm_bin="$(command -v npm)"
+                  npm_cli="$(NODE_PATH='' "${node_bin}" -p 'require("npm/package.json").bin.npm-cli' 2>/dev/null || true)"
+                  if [ -n "${npm_cli}" ] && [ -f "$(dirname "${npm_bin}")/../lib/node_modules/npm/${npm_cli}" ]; then
+                    npm_cli="$(dirname "${npm_bin}")/../lib/node_modules/npm/${npm_cli}"
+                  elif [ -f "${TOOLS_DIR}/npm/bin/npm-cli.js" ]; then
+                    npm_cli="${TOOLS_DIR}/npm/bin/npm-cli.js"
+                  else
+                    npm_cli=""
+                  fi
+                fi
+
+                if [ -z "${npm_cli}" ]; then
+                  npm_tgz="${TOOLS_DIR}/npm.tgz"
+                  npm_extract_dir="${TOOLS_DIR}/npm-src"
+                  rm -rf "${npm_extract_dir}"
+                  if command -v curl > /dev/null 2>&1; then
+                    if curl -fsSL "https://registry.npmjs.org/npm/-/npm-10.9.2.tgz" -o "${npm_tgz}"; then
+                      mkdir -p "${npm_extract_dir}"
+                      tar -xzf "${npm_tgz}" -C "${npm_extract_dir}"
+                      rm -rf "${TOOLS_DIR}/npm"
+                      mv "${npm_extract_dir}/package" "${TOOLS_DIR}/npm"
+                      npm_cli="${TOOLS_DIR}/npm/bin/npm-cli.js"
+                    fi
+                  fi
+                fi
+
+                if [ -z "${npm_cli}" ] || [ ! -f "${npm_cli}" ]; then
+                  echo "WARNING: npm bootstrap unavailable; skipping @github/copilot CLI install." >&2
+                  return 0
+                fi
+
+                copilot_prefix="${TOOLS_DIR}/copilot-cli"
+                rm -rf "${copilot_prefix}"
+                if "${node_bin}" "${npm_cli}" install --silent --no-fund --no-audit --prefix "${copilot_prefix}" @github/copilot; then
+                  copilot_loader="${copilot_prefix}/node_modules/@github/copilot/npm-loader.js"
+                  if [ -f "${copilot_loader}" ]; then
+                    printf '%s\n' \
+                      '#!/bin/sh' \
+                      'set -eu' \
+                      '' \
+                      'node_bin=""' \
+                      'if command -v node > /dev/null 2>&1; then' \
+                      '  node_bin="$(command -v node)"' \
+                      'elif [ -x /home/.openvscode-server/node ]; then' \
+                      '  node_bin="/home/.openvscode-server/node"' \
+                      'fi' \
+                      '' \
+                      'if [ -z "${node_bin}" ]; then' \
+                      '  echo "copilot: node runtime not found" >&2' \
+                      '  exit 127' \
+                      'fi' \
+                      '' \
+                      'exec "${node_bin}" /var/lib/openvscode/tools/copilot-cli/node_modules/@github/copilot/npm-loader.js "$@"' \
+                      > "${BIN_DIR}/copilot"
+                    chmod +x "${BIN_DIR}/copilot"
+                  fi
+                else
+                  echo "WARNING: failed to install @github/copilot CLI; continuing without it." >&2
+                fi
+              }
+
+              install_official_copilot_cli
+
+              printf '%s\n' '{' \
+                '  "telemetry.telemetryLevel": "off",' \
+                '  "security.workspace.trust.enabled": false,' \
+                '  "workbench.startupEditor": "none"' \
+                '}' > "${DATA_DIR}/Machine/settings.json"
+          volumeMounts:
+            - name: openvscode-data
+              mountPath: /var/lib/openvscode
+
+      containers:
+        - name: openvscode-server
+          image: __IMAGE__
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -lc
+          args:
+            - |
+              set -eu
+              if command -v openvscode-server > /dev/null 2>&1; then
+                exec openvscode-server --host 0.0.0.0 --port 3000 --without-connection-token --extensions-dir /var/lib/openvscode/extensions --user-data-dir /var/lib/openvscode/data /home/workspace
+              fi
+              exec /home/.openvscode-server/bin/openvscode-server --host 0.0.0.0 --port 3000 --without-connection-token --extensions-dir /var/lib/openvscode/extensions --user-data-dir /var/lib/openvscode/data /home/workspace
+          ports:
+            - containerPort: 3000
+              name: http
+            - containerPort: 3030
+              name: proxy
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          volumeMounts:
+            - name: openvscode-data
+              mountPath: /var/lib/openvscode
+            - name: workspace
+              mountPath: /home/workspace
+      volumes:
+        - name: openvscode-data
+          persistentVolumeClaim:
+            claimName: __RELEASE__-data
+        - name: workspace
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: __RELEASE__
+  namespace: __NAMESPACE__
+  labels:
+    app.kubernetes.io/name: __RELEASE__
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: __RELEASE__
+  ports:
+    - name: http
+      port: 3000
+      targetPort: http
+    - name: proxy
+      port: 3030
+      targetPort: proxy
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: __RELEASE__-internal
+  namespace: __NAMESPACE__
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: __RELEASE__
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector: {}


### PR DESCRIPTION
## Summary

This draft PR restores two experimental recipes that were intentionally removed from the merged OpenClaw hardening branch:

- `truthbrush-poller`
- `vscode-copilot-proxy`

The goal is to keep the experiments available in isolation for further iteration without mixing them back into production-oriented PRs.

## Scope

Restored files:
- `scripts/recipes/truthbrush-poller/install.sh`
- `scripts/recipes/truthbrush-poller/README.md`
- `scripts/recipes/vscode-copilot-proxy/install.sh`
- `scripts/recipes/vscode-copilot-proxy/README.md`
- `scripts/recipes/vscode-copilot-proxy/manifests.yaml`

Re-added discoverability references:
- `cmd/netcup-kube/install.go`
- `docs/cli-contract.md`
- `scripts/recipes/README.md`

## Validation

- `make check`
- `go test ./cmd/netcup-kube/...`

## Notes

This is a spike PR, not a merge-ready production change.

Known caveats:
- `vscode-copilot-proxy` was experimental and previously did not fully work as intended.
- `truthbrush-poller` is restored for further exploration, not because it has been production-hardened.
- Security, packaging, and runtime behavior for both recipes likely still need follow-up before either should be merged into `main`.

## Suggested next steps

- Decide whether each experiment should continue independently.
- Either harden one recipe at a time in follow-up commits, or close the spike after harvesting the useful parts.